### PR TITLE
FIX Don't consider pairing balancer when MM/Score difference is more than 1

### DIFF
--- a/GoCarlos.NET.csproj
+++ b/GoCarlos.NET.csproj
@@ -4,7 +4,7 @@
     <!--Metadata-->
     <Authors>Boris Dovčík</Authors>
     <Title>GoCarlos</Title>
-    <Version>0.0.16</Version>
+    <Version>0.0.17</Version>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/borisho/GoCarlos.NET</RepositoryUrl>
     <VisualStudioVersion>18.1.1</VisualStudioVersion>

--- a/Models/PairingGenerator.cs
+++ b/Models/PairingGenerator.cs
@@ -195,14 +195,9 @@ public static class PairingGenerator
                 IEnumerable<IGrouping<float, Player>> groups = opponents.GroupBy(p => p.Score);
                 IEnumerable<Player> strongestGroup = groups.First();
 
-                // vyberú sa hráči, ktorý majú byť dosadení podľa pairingBalancera
-                lowestPairingBalancer = strongestGroup.Min(p => CalculatePairingBalancer(p, roundNumber));
-                IEnumerable<Player> subGroup = strongestGroup
-                    .Where(p => CalculatePairingBalancer(p, roundNumber) == lowestPairingBalancer);
-
                 // pokiaľ je to možné vyhni sa hendikepu viac ako 9
-                subGroup = TryToAvoidHighHandicap(subGroup, player, parameters.HandicapReduction);
-                opponent = OpponentSelection(parameters.AdditionMethod, subGroup);
+                strongestGroup = TryToAvoidHighHandicap(strongestGroup, player, parameters.HandicapReduction);
+                opponent = OpponentSelection(parameters.AdditionMethod, strongestGroup);
 
                 pairing = PairPlayers(
                     new PairingParameters(

--- a/Models/Utils.cs
+++ b/Models/Utils.cs
@@ -9,7 +9,7 @@ namespace GoCarlos.NET.Models;
 
 internal static class Utils
 {
-    public const string VERSION = "0.0.16";
+    public const string VERSION = "0.0.17";
     public const string BYE = "0+";
     public const string QUESTION_MARK = "?";
     public const string EQUALS = "=";

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pairing program for Go tournaments. Created for the needs of the Slovak Championship and to learn something new.
 
-Current version: 0.0.15
+Current version: 0.0.17
 
 ## Support
 


### PR DESCRIPTION
# Problem
Slovak Championship algorithm states that pairing balancer should be considered only in case of MM/Score difference of one, which is currently not the case.

# Solution
In case of MM/Score difference greater than one, do not consider pairing balancer as per Slovak Championship algorithm specification.